### PR TITLE
Handle `GLOBAL_DEF` overload

### DIFF
--- a/scripts/extract_properties.py
+++ b/scripts/extract_properties.py
@@ -55,7 +55,7 @@ message_patterns = {
         r'EDITOR_SETTING(_USAGE)?\(Variant::[_A-Z0-9]+, [_A-Z0-9]+, "(?P<message>[^"]+?)",'
     ): ExtractType.PROPERTY_PATH,
     re.compile(
-        r"(ADD_PROPERTYI?|ImportOption|ExportOption)\(PropertyInfo\("
+        r"(ADD_PROPERTYI?|GLOBAL_DEF(_RST)?(_NOVAL)?(_BASIC)?|ImportOption|ExportOption)\(PropertyInfo\("
         + r"Variant::[_A-Z0-9]+"  # Name
         + r', "(?P<message>[^"]+)"'  # Type
         + r'(, [_A-Z0-9]+(, "(?P<hint_string>(?:[^"\\]|\\.)*)"(, (?P<usage>[_A-Z0-9]+))?)?|\))'  # [, hint[, hint string[, usage]]].


### PR DESCRIPTION
`GLOBAL_DEF` has two overloads. One takes a string, and one takes a `PropertyInfo`. The latter is currently not handled so some entries in the project settings are not on Weblate.

This adds about 100 msgids:

```
#   Additions: 162 msgids.
#   Deletions: 33 msgids.
```