### PR TITLE
Add base strings for note about C# differences and empty descriptions

### DIFF
--- a/scripts/extract_classes.py
+++ b/scripts/extract_classes.py
@@ -56,6 +56,15 @@ BASE_STRINGS = [
     "This method doesn't need an instance to be called, so it can be called directly using the class name.",
     "This method describes a valid operator to use with this type as left-hand operand.",
     "This value is an integer composed as a bitmask of the following flags.",
+    "There is currently no description for this class. Please help us by :ref:`contributing one <doc_updating_the_class_reference>`!",
+    "There is currently no description for this signal. Please help us by :ref:`contributing one <doc_updating_the_class_reference>`!",
+    "There is currently no description for this annotation. Please help us by :ref:`contributing one <doc_updating_the_class_reference>`!",
+    "There is currently no description for this property. Please help us by :ref:`contributing one <doc_updating_the_class_reference>`!",
+    "There is currently no description for this constructor. Please help us by :ref:`contributing one <doc_updating_the_class_reference>`!",
+    "There is currently no description for this method. Please help us by :ref:`contributing one <doc_updating_the_class_reference>`!",
+    "There is currently no description for this operator. Please help us by :ref:`contributing one <doc_updating_the_class_reference>`!",
+    "There is currently no description for this theme property. Please help us by :ref:`contributing one <doc_updating_the_class_reference>`!",
+    "There are notable differences when using this API with C#. See :ref:`doc_c_sharp_differences` for more information.",
 ]
 
 ## <xml-line-number-hack from="https://stackoverflow.com/a/36430270/10846399">


### PR DESCRIPTION
- Sync with the strings added in https://github.com/godotengine/godot/pull/79206.