### PR TITLE
Exclude `tests` folder from string extraction

### DIFF
--- a/scripts/common.py
+++ b/scripts/common.py
@@ -113,7 +113,7 @@ class PropertyNameProcessor:
 def get_source_files() -> List[str]:
     matches = []
     for root, dirnames, filenames in os.walk("."):
-        dirnames[:] = [d for d in dirnames if d not in ["thirdparty"]]
+        dirnames[:] = [d for d in dirnames if d not in ["tests", "thirdparty"]]
         for filename in fnmatch.filter(filenames, "*.cpp"):
             matches.append(os.path.join(root, filename))
         for filename in fnmatch.filter(filenames, "*.h"):


### PR DESCRIPTION
This prevents properties defined in tests to be extracted:

```diff
diff --git i/properties/properties.pot w/properties/properties.pot
index e817531..9bb9169 100644
--- i/properties/properties.pot
+++ w/properties/properties.pot
@@ -15356,23 +15356,3 @@ msgstr ""
 #: servers/xr_server.cpp
 msgid "Primary Interface"
 msgstr ""
-
-#: tests/core/object/test_object.h tests/core/object/test_undo_redo.h
-msgid "Property"
-msgstr ""
-
-#: tests/scene/test_instance_placeholder.h
-msgid "Int Property"
-msgstr ""
-
-#: tests/scene/test_instance_placeholder.h
-msgid "Reference Property"
-msgstr ""
-
-#: tests/scene/test_instance_placeholder.h
-msgid "Reference Array Property"
-msgstr ""
-
-#: tests/scene/test_node.h
-msgid "Exported Node"
-msgstr ""

```