### PR TITLE
Fix basic editor settings not extracted

### DIFF
--- a/scripts/extract_properties.py
+++ b/scripts/extract_properties.py
@@ -50,9 +50,9 @@ msgstr ""
 message_patterns = {
     re.compile(r'_initial_set\("(?P<message>[^"]+?)",'): ExtractType.PROPERTY_PATH,
     re.compile(r'GLOBAL_DEF(_RST)?(_NOVAL)?(_BASIC)?\("(?P<message>[^"]+?)",'): ExtractType.PROPERTY_PATH,
-    re.compile(r'(?P<editor_setting>EDITOR_DEF(_RST)?)\("(?P<message>[^"]+?)",'): ExtractType.PROPERTY_PATH,
+    re.compile(r'(?P<editor_setting>EDITOR_DEF(_RST|_BASIC)?)\("(?P<message>[^"]+?)",'): ExtractType.PROPERTY_PATH,
     re.compile(
-        r'(?P<editor_setting>EDITOR_SETTING(_USAGE)?)\(Variant::[_A-Z0-9]+, [_A-Z0-9]+, "(?P<message>[^"]+?)",'
+        r'(?P<editor_setting>EDITOR_SETTING(_USAGE|_BASIC)?)\(Variant::[_A-Z0-9]+, [_A-Z0-9]+, "(?P<message>[^"]+?)",'
     ): ExtractType.PROPERTY_PATH,
     re.compile(
         r"(ADD_PROPERTYI?|GLOBAL_DEF(_RST)?(_NOVAL)?(_BASIC)?|ImportOption|ExportOption)\(PropertyInfo\("


### PR DESCRIPTION
https://github.com/godotengine/godot/pull/96467 introduced advanced toggle to Editor Settings.

Basic settings are switched to use the new `EDITOR_DEF_BASIC` macro.